### PR TITLE
insert_with_params.m to support both Verilog 95/2001 module header style

### DIFF
--- a/matlab_compatible/insert_with_params.m
+++ b/matlab_compatible/insert_with_params.m
@@ -196,7 +196,6 @@ end
                 plist{cnt}.name = param{1}.n;
                 plist{cnt}.value = param{1}.v;
             end
-            fprintf('%3d:  name=%s  value=%s\n', cnt, plist{cnt}.name, plist{cnt}.value);
             cnt = cnt + 1;
         end
     end
@@ -231,7 +230,6 @@ end
                 ilist{cnt}.inout_type = inout_type;
                 ilist{cnt}.brackets   = param{1}.b;
             end
-            fprintf('%3d:  name=%s  value=%s\n', cnt, plist{cnt}.name, plist{cnt}.value);
             cnt = cnt + 1;
         end
         


### PR DESCRIPTION
I have added old-fashion module format support to "insert_with_params.m"

[counter.zip](https://github.com/amromanov/vmodel/files/189431/counter.zip)

Verilog 2001 define this syntax:
module counter
  #(parameter R=4)
  (
   input clk,
   input Rst,
   output reg [R-1:0] cnt
   );

Verilog 95 define this syntax:
module counter (
   clk,
   Rst,
   cnt
   );

   parameter R = 4;

   input clk;
   input Rst;
   output [R-1:0] cnt;

   reg [R-1:0]    cnt;
